### PR TITLE
Fix handling of operators in the 'add-to-import-list option

### DIFF
--- a/attrap.el
+++ b/attrap.el
@@ -312,7 +312,7 @@ usage: (attrap-alternatives CLAUSES...)"
         (move-to-column (1- end-col))
         (skip-chars-backward " \t")
         (unless (looking-back "(" (- (point) 2)) (insert ","))
-        (insert missing))))
+        (insert (attrap-add-operator-parens missing)))))
     ;; Not in scope: data constructor ‘SimpleBroadcast’
     ;; Perhaps you meant ‘SimpleBroadCast’ (imported from TypedFlow.Types)
 ;;     Not in scope: ‘BackCore.argmax’
@@ -377,6 +377,12 @@ usage: (attrap-alternatives CLAUSES...)"
              (goto-char 1)
              (insert (concat "{-# LANGUAGE " it " #-}\n")))
            (--filter (s-matches? it msg) attrap-haskell-extensions)))))
+
+(defun attrap-add-operator-parens (name)
+  "Add parens around a NAME if it refers to a Haskell operator."
+  (if (string-match-p "^[[:upper:][:lower:]_']" name)
+      name
+    (concat "(" name ")")))
 
 (provide 'attrap)
 ;;; attrap.el ends here


### PR DESCRIPTION
Currently when attrap responds to an error message like

```
• Variable not in scope:
    (<+>)
      :: m0 a0
         -> Data.Text.Prettyprint.Doc.Internal.Doc ann0 -> m Constants
• Perhaps you meant one of these:
    ‘<>’ (imported from Prelude), ‘<*>’ (imported from Prelude),
    ‘<$>’ (imported from Prelude)
  Perhaps you want to add ‘<+>’ to the import list in the import of
  ‘Data.Text.Prettyprint.Doc’
  (/foo/bar/baz/Quux.hs:25:1-45).
```

it will do the following fix
```haskell
import Data.Text.Prettyprint.Doc (Pretty(..),<+>)
```

But that's syntactically invalid! This PR makes the fix look like
```haskell
import Data.Text.Prettyprint.Doc (Pretty(..),(<+>))
```

The only tricky part here is to detect whether a name should be enclosed in parens, i.e. whether it's an operator. Since there's no dependency on haskell-mode which does have regexps to reliably ascertain that, I've settled on a less principled but more lightweight solution of treating anything that does not start with an uppercase, lowercase, `_` or `'` letter as an operator. Please let me know if you have any ideas on how this could be improved.