### PR TITLE
Improve regex for hole fits, when there is a nested signature

### DIFF
--- a/attrap.el
+++ b/attrap.el
@@ -299,7 +299,7 @@ usage: (attrap-alternatives CLAUSES...)"
         (end-of-line)
         (insert "\nimport Data.Kind (Type)"))))
    (when (string-match "Valid hole fits include" msg)
-    (let* ((options (-map 'cadr (-non-nil (--map (s-match "[ ]*\\(.*\\) ::" it) (s-split "\n" (substring msg (match-end 0))))))))
+    (let* ((options (-map 'cadr (-non-nil (--map (s-match "[ ]*\\([^ ]*\\) ::" it) (s-split "\n" (substring msg (match-end 0))))))))
       (--map (attrap-option (list 'plug-hole it)
                      (goto-char pos)
                      (delete-char 1)


### PR DESCRIPTION
When GHC suggests hole fits it uses the template

    identifier :: type

However, sometimes `type` contains colons too, for example

    foo :: Foo (p :: ADataKind)

The previous regex matched

    foo :: Foo (p

This one matches

    foo

---

I'm not sure this is really the correct fix, but it seems better than the status quo.